### PR TITLE
SMARTS fix for bond highlighting

### DIFF
--- a/depict/utils.py
+++ b/depict/utils.py
@@ -118,10 +118,17 @@ def create_svg(m):
 
 def create_png_jpeg_image(m, filename, format, size, smarts):
     # extension = ImageFormat.PNG.value if format == ImageFormat.PNG.value else ImageFormat.JPG.value
-    smart = Chem.MolFromSmarts(smarts)
-    highlight = m.GetSubstructMatch(smart)
-    print(highlight)
-    pil_image = Draw.MolToImage(m, size= size, highlightAtoms = highlight)
+    substructure = Chem.MolFromSmarts(smarts)
+    atom_matches = sum(m.GetSubstructMatches(substructure), ()) # this just combines the tuple of tuples into a single tuple
+    # to properly highlight bonds must get all bonds that are between matched atoms
+    bond_matches = []
+    for atom_idx in atom_matches:
+        atom = m.GetAtomWithIdx(atom_idx)
+        for neighbor in atom.GetNeighbors():
+            bond = m.GetBondBetweenAtoms(atom.GetIdx(), neighbor.GetIdx())
+            if (bond is not None) and neighbor.GetIdx() in atom_matches:
+                bond_matches.append(bond.GetIdx())
+    pil_image = Draw.MolToImage(m, size=size, highlightAtoms=atom_matches, highlightBonds=bond_matches)
     pil_image.save("{}.{}".format(filename, format))
 
     name = filename + ".{}".format(format)

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -119,16 +119,14 @@ def create_svg(m):
 def create_png_jpeg_image(m, filename, format, size, smarts):
     # extension = ImageFormat.PNG.value if format == ImageFormat.PNG.value else ImageFormat.JPG.value
     substructure = Chem.MolFromSmarts(smarts)
-    atom_matches = sum(m.GetSubstructMatches(substructure), ()) # this just combines the tuple of tuples into a single tuple
-    # to properly highlight bonds must get all bonds that are between matched atoms
+    all_atom_matches = m.GetSubstructMatches(substructure)
     bond_matches = []
-    for atom_idx in atom_matches:
-        atom = m.GetAtomWithIdx(atom_idx)
-        for neighbor in atom.GetNeighbors():
-            bond = m.GetBondBetweenAtoms(atom.GetIdx(), neighbor.GetIdx())
-            if (bond is not None) and neighbor.GetIdx() in atom_matches:
-                bond_matches.append(bond.GetIdx())
-    pil_image = Draw.MolToImage(m, size=size, highlightAtoms=atom_matches, highlightBonds=bond_matches)
+    for atom_matches in all_atom_matches:
+        for bond in substructure.GetBonds():
+            idx1, idx2 = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            bond_matches.append(m.GetBondBetweenAtoms(atom_matches[idx1], atom_matches[idx2]).GetIdx())
+    all_atom_matches = sum(m.GetSubstructMatches(substructure), ()) # this just combines the tuple of tuples into a single tuple
+    pil_image = Draw.MolToImage(m, size=size, highlightAtoms=all_atom_matches, highlightBonds=bond_matches)
     pil_image.save("{}.{}".format(filename, format))
 
     name = filename + ".{}".format(format)

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -125,7 +125,7 @@ def create_png_jpeg_image(m, filename, format, size, smarts):
         for bond in substructure.GetBonds():
             idx1, idx2 = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
             bond_matches.append(m.GetBondBetweenAtoms(atom_matches[idx1], atom_matches[idx2]).GetIdx())
-    all_atom_matches = sum(m.GetSubstructMatches(substructure), ()) # this just combines the tuple of tuples into a single tuple
+    all_atom_matches = sum(all_atom_matches, ()) # this just combines the tuple of tuples into a single tuple
     pil_image = Draw.MolToImage(m, size=size, highlightAtoms=all_atom_matches, highlightBonds=bond_matches)
     pil_image.save("{}.{}".format(filename, format))
 


### PR DESCRIPTION
Fixed issue where bonds were not highlighting when using SMARTS. I've compared the output to the examples from the RDKit tutorials [here](https://github.com/rdkit/rdkit-tutorials/blob/master/notebooks/002_SMARTS_SubstructureMatching.ipynb) and they match. I've also done some small testing on my own and the highlighting seems to work as expected.