### PR TITLE
Allow for DEBUG=0 in Production

### DIFF
--- a/cfchem/settings.py
+++ b/cfchem/settings.py
@@ -10,8 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
-from pathlib import Path
 import os
+from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -127,7 +127,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')


### PR DESCRIPTION
After merging #14 and pulling on the EC2 server I noticed that there was a "Server Error: 500" problem when running with `DEBUG=0` (the error was not present with `DEBUG=1`). After some debugging I figured out the problem was with static files (see attached log if interested in details of the error). The fix was to change `STATICFILES_STORAGE`, as described here: https://stackoverflow.com/a/56259827

I've tested this change and the website now works as expected with `DEBUG=0`

Detailed error log (prior to fix): 
[depict.log](https://github.com/unmtransinfo/CFChemApps/files/13866896/depict.log)

