### PR TITLE
Add option to align SMARTS substructures

### DIFF
--- a/cfchem/settings.py
+++ b/cfchem/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = ["206.192.180.166", "127.0.0.1", "chiltepin.health.unm.edu", "lo
 # Application definition
 
 INSTALLED_APPS = [
+    "whitenoise.runserver_nostatic", # for development
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -103,9 +103,9 @@ def get_atom_bond_matches(m, smarts):
     return all_atom_matches, bond_matches, substructure
 
 
-def create_image(m, filename, format, size, smarts, first_match_coords=None):
+def create_image(m, filename, format, size, smarts, first_match_coords=None, align_smarts: bool = False):
     all_atom_matches, bond_matches, substructure = get_atom_bond_matches(m, smarts)
-    if len(all_atom_matches) > 0 or len(bond_matches) > 0:
+    if align_smarts and (len(all_atom_matches) > 0 or len(bond_matches) > 0):
         # have match to smarts
         match = m.GetSubstructMatch(substructure)
         if first_match_coords is not None:
@@ -150,10 +150,11 @@ def get_svgs_from_mol_file(filename, format, size, smarts):
         output.append([image_name, name])
     return output
 
-def get_svgs_from_data(datas, format, size, smarts):
+def get_svgs_from_data(datas, format, size, smarts, align_smarts: bool):
     output = []
     counter = 0
     # track coordinates of first smarts match to use for subsequent matches
+    # no effect if align_smarts == False
     first_match_coords = None
     for d in datas:     
         d = d.strip() 
@@ -174,7 +175,7 @@ def get_svgs_from_data(datas, format, size, smarts):
         comp = Chem.MolFromSmiles(smile)
 
         filename = name if name != NO_COMPOUND_NAME else generate_random_name()
-        image_name, first_match_coords = create_image(comp, create_media_filename(filename), format, size, smarts, first_match_coords) 
+        image_name, first_match_coords = create_image(comp, create_media_filename(filename), format, size, smarts, first_match_coords, align_smarts) 
         counter += 1
         print(image_name, name)
         output.append([image_name, name])

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -90,7 +90,7 @@ def create_media_filename(filename):
     return "{}/{}".format(MEDIA_FOLDER, filename)
 
 
-def create_image(m, filename, format, size, smarts):
+def get_atom_bond_matches(m, smarts):
     substructure = Chem.MolFromSmarts(smarts)
     all_atom_matches = m.GetSubstructMatches(substructure)
     bond_matches = []
@@ -99,6 +99,11 @@ def create_image(m, filename, format, size, smarts):
             idx1, idx2 = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
             bond_matches.append(m.GetBondBetweenAtoms(atom_matches[idx1], atom_matches[idx2]).GetIdx())
     all_atom_matches = sum(all_atom_matches, ()) # this just combines the tuple of tuples into a single tuple
+    return all_atom_matches, bond_matches
+
+
+def create_image(m, filename, format, size, smarts):
+    all_atom_matches, bond_matches = get_atom_bond_matches(m, smarts)
     img_name = "{}.{}".format(filename, format)
     if format in [ImageFormat.JPG.value, ImageFormat.PNG.value]:
         pil_image = Draw.MolToImage(m, size=size, highlightAtoms=all_atom_matches, highlightBonds=bond_matches)

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -140,7 +140,6 @@ def get_svgs_from_mol_file(filename, format, size, smarts, align_smarts: bool):
     output = []
     counter = 0
     suppl = Chem.SDMolSupplier(filename)
-    print(filename)
     first_match_coords = None
     for mol in suppl:
         if mol is None:

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -1,4 +1,5 @@
 from rdkit import Chem
+from rdkit.Chem import AllChem
 from rdkit.Chem import Draw
 
 from django.core.files.storage import FileSystemStorage
@@ -99,11 +100,14 @@ def get_atom_bond_matches(m, smarts):
             idx1, idx2 = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
             bond_matches.append(m.GetBondBetweenAtoms(atom_matches[idx1], atom_matches[idx2]).GetIdx())
     all_atom_matches = sum(all_atom_matches, ()) # this just combines the tuple of tuples into a single tuple
-    return all_atom_matches, bond_matches
+    return all_atom_matches, bond_matches, substructure
 
 
 def create_image(m, filename, format, size, smarts):
-    all_atom_matches, bond_matches = get_atom_bond_matches(m, smarts)
+    all_atom_matches, bond_matches, substructure = get_atom_bond_matches(m, smarts)
+    if len(all_atom_matches) > 0 or len(bond_matches) > 0:
+        AllChem.Compute2DCoords(substructure)
+        AllChem.GenerateDepictionMatching2DStructure(m, substructure)
     img_name = "{}.{}".format(filename, format)
     if format in [ImageFormat.JPG.value, ImageFormat.PNG.value]:
         pil_image = Draw.MolToImage(m, size=size, highlightAtoms=all_atom_matches, highlightBonds=bond_matches)

--- a/depict/utils.py
+++ b/depict/utils.py
@@ -136,16 +136,18 @@ def create_image(m, filename, format, size, smarts, first_match_coords=None, ali
     return img_name, first_match_coords
 
 
-def get_svgs_from_mol_file(filename, format, size, smarts):
+def get_svgs_from_mol_file(filename, format, size, smarts, align_smarts: bool):
     output = []
     counter = 0
     suppl = Chem.SDMolSupplier(filename)
+    print(filename)
+    first_match_coords = None
     for mol in suppl:
         if mol is None:
             continue
 
         name = mol.GetProp("_Name")
-        image_name = create_image(mol, create_media_filename(name), format, size, smarts)
+        image_name, first_match_coords = create_image(mol, create_media_filename(name), format, size, smarts, first_match_coords, align_smarts)
         counter += 1
         output.append([image_name, name])
     return output

--- a/depict/views.py
+++ b/depict/views.py
@@ -16,6 +16,8 @@ def get_mols(request, type):
     format = request.POST.get("imgfmt")
     size = request.POST.get("size")
     smarts = request.POST.get("smarts")
+    align_smarts = request.POST.get('alignSmarts', 'off') == 'on'
+
 
     size = get_image_size(size)
 
@@ -41,7 +43,7 @@ def get_mols(request, type):
         else:
             input_text, datas = get_content(type, request)
 
-    output = get_svgs_from_data(datas, format, size, smarts)
+    output = get_svgs_from_data(datas, format, size, smarts, align_smarts)
     context = {
         IMAGES: output,
         INPUT_TEXT: input_text

--- a/depict/views.py
+++ b/depict/views.py
@@ -31,7 +31,7 @@ def get_mols(request, type):
                 input_text, datas = get_content_from_csv(filename)
                 delete_file(filename)
             elif type == FileType.MOL or type == FileType.SDF:
-                output = get_svgs_from_mol_file(filename, format, size, smarts)
+                output = get_svgs_from_mol_file(filename, format, size, smarts, align_smarts)
                 input_text = get_content_from_file(filename)
                 context = {
                     IMAGES: output,

--- a/depict/views.py
+++ b/depict/views.py
@@ -1,10 +1,6 @@
-from rdkit.Chem import AllChem  
-
 from django.shortcuts import render
 
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.response import Response
-from rest_framework import status
+from rest_framework.decorators import api_view
 
 from .utils import *
 

--- a/entrypoint.dev.sh
+++ b/entrypoint.dev.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# Collect static files
-echo "Collect static files"
-python manage.py collectstatic -i media --clear --noinput
+# static file collection not needed in development with whitenoise
 
 python manage.py makemigrations
 # Apply database migrations

--- a/templates/depict/help.html
+++ b/templates/depict/help.html
@@ -30,11 +30,11 @@
         User can choose the image format (PNG, JPEG, or SVG) as per
         their requirements, and upload a Mol File or SMILES (csv)
         in order to get the structure of the compounds.
-
-        The DEMO button can be used to test run the portal
-        with some pre existing SMILE representations.
-
-        The RESET button can be used to reset any inputs for processing
+        <ul>
+            <li>The DEMO button can be used to test run the portal with some pre-existing SMILE representations.</li>
+            <li>The RESET button can be used to reset any inputs for processing.</li>
+            <li>The "Align SMARTS" toggles whether or not to align SMARTS substructures.</li>
+        </ul>
     </p>
     <p>
         Lead Developer: <a href="https://github.com/Priyansh-Kedia" target="_blank">Priyansh Kedia</a>

--- a/templates/depict/help.html
+++ b/templates/depict/help.html
@@ -33,7 +33,7 @@
         <ul>
             <li>The DEMO button can be used to test run the portal with some pre-existing SMILE representations.</li>
             <li>The RESET button can be used to reset any inputs for processing.</li>
-            <li>The "Align SMARTS" toggles whether or not to align SMARTS substructures.</li>
+            <li>The ALIGN SMARTS checkbox toggles whether or not to align SMARTS substructures.</li>
         </ul>
     </p>
     <p>

--- a/templates/depict/index.html
+++ b/templates/depict/index.html
@@ -261,8 +261,10 @@
             <td valign="top">
                 <b>smarts: </b><br><br>
                 <input type="text" name="smarts" id="smartsEntry" size="48" value="">
+                <br>
+                <label for="alignSmarts">Align SMARTS</label>
+                <input type="checkbox" id="alignSmarts" name="alignSmarts" checked>
             </td>
-
             <script>
                 // set smarts query if it was previously set
                 var smartsValue = sessionStorage.getItem("smarts");
@@ -276,6 +278,20 @@
                 smartsElement.addEventListener("change", function() {
                     var smarts = smartsElement.value;
                     sessionStorage.setItem("smarts", smarts);
+                });
+            </script>
+            <script>
+                // set alignSmarts checkbox if it was previously set
+                var alignSmartsValue = sessionStorage.getItem("alignSmarts");
+                var alignSmartsElement = document.getElementById("alignSmarts");
+            
+                if (alignSmartsValue !== null) {
+                    alignSmartsElement.checked = alignSmartsValue === "true";
+                }
+            
+                // add event listener to persist alignSmarts checkbox
+                alignSmartsElement.addEventListener("change", function() {
+                    sessionStorage.setItem("alignSmarts", alignSmartsElement.checked);
                 });
             </script>
         </TR>

--- a/templates/depict/index.html
+++ b/templates/depict/index.html
@@ -56,7 +56,7 @@
         newWindow.document.close();
     }
 
-    function set_listeners() {
+    function setListeners() {
         var modal = document.getElementById('myModal');
         var modalImg = document.getElementById("img01");
         const captionText = document.getElementById("caption");
@@ -101,7 +101,6 @@
 </script>
 
 <script>
-    // window.onload = function() {
     function readFile() {
         document.getElementById('infile').addEventListener('change', function () {
             var file_reader = new FileReader();
@@ -111,7 +110,6 @@
             file_reader.readAsText(this.files[0]);
         })
     }
-    // }
 </script>
 
 <script type="text/javascript">
@@ -138,7 +136,7 @@
 <script>
 
     window.onload = function () {
-        set_listeners();
+        setListeners();
         readFile();
         adjustImageGrid();
         adjustImageContentWidths();
@@ -261,8 +259,24 @@
             
             <td valign="top">
                 <b>smarts: </b><br><br>
-                <input type="text" name="smarts" size="48" value="">
+                <input type="text" name="smarts" id="smartsEntry" size="48" value="">
             </td>
+
+            <script>
+                // set smarts query if it was previously set
+                var smartsValue = sessionStorage.getItem("smarts");
+                var smartsElement = document.getElementById("smartsEntry");
+
+                if (smartsValue !== null) {
+                    smartsElement.value = smartsValue;
+                }
+
+                // add event listener to persist smarts query
+                smartsElement.addEventListener("change", function() {
+                    var smarts = smartsElement.value;
+                    sessionStorage.setItem("smarts", smarts);
+                });
+            </script>
         </TR>
     </TABLE>
     <P>

--- a/templates/depict/index.html
+++ b/templates/depict/index.html
@@ -36,6 +36,7 @@
     }
 
     function reset() {
+        sessionStorage.clear(); // reset options to defaults
         let url = "{% url 'index' %}"
         document.location.href = url
     }


### PR DESCRIPTION
This is a feature requested by Jeremy. To make it easier to compare molecules which contain a SMARTS substructure, an option has been added so that molecules with a match are aligned to a common structure (the first match). See images below as a comparison with and without this option (using 
[benzodiazepine.csv](https://github.com/unmtransinfo/CFChemApps/files/14057905/benzodiazepine.csv) as input with SMARTS query ` [#7]~1~[#6]~[#6]~[#7]~[#6]~[#6]~2~[#6]~[#6]~[#6]~[#6]~[#6]12` ). 

Without SMARTS alignment:
![image](https://github.com/unmtransinfo/CFChemApps/assets/97483169/fd95d567-5a90-499b-bf3e-2f75a69f586f)

With SMARTS alignment:
![image](https://github.com/unmtransinfo/CFChemApps/assets/97483169/fd520834-7f06-4aa9-b57c-cf5542eec110)


Some other minor changes/fixes were also made:
- Fixed issue between whitenoise and Django that was causing static files to not load properly in development mode
- Made it so input SMARTS persist across page reloads (this was requested by Jeremy as well)
- RESET button resets all inputs, not just input file/text
- Minor changes to the Help page (added info on the Align SMARTS checkbox)